### PR TITLE
Added null check to VehicleHandler equality comparison.

### DIFF
--- a/Source/Vehicles/Components/Vehicles/VehicleHandler.cs
+++ b/Source/Vehicles/Components/Vehicles/VehicleHandler.cs
@@ -80,8 +80,8 @@ namespace Vehicles
 				return role != null &&  reservation && handlers.Count < role.slots;
 			}
 		}
-
-		public static bool operator ==(VehicleHandler obj1, VehicleHandler obj2) => !(obj1 is null) && obj1.Equals(obj2);
+		
+		public static bool operator ==(VehicleHandler obj1, VehicleHandler obj2) => ((obj1 is null) && (obj2 is null)) || (!(obj1 is null) && obj1.Equals(obj2));
 
 		public static bool operator !=(VehicleHandler obj1, VehicleHandler obj2) => !(obj1 == obj2);
 

--- a/Source/Vehicles/Components/Vehicles/VehicleHandler.cs
+++ b/Source/Vehicles/Components/Vehicles/VehicleHandler.cs
@@ -81,7 +81,7 @@ namespace Vehicles
 			}
 		}
 
-		public static bool operator ==(VehicleHandler obj1, VehicleHandler obj2) => obj1.Equals(obj2);
+		public static bool operator ==(VehicleHandler obj1, VehicleHandler obj2) => !(obj1 is null) && obj1.Equals(obj2);
 
 		public static bool operator !=(VehicleHandler obj1, VehicleHandler obj2) => !(obj1 == obj2);
 


### PR DESCRIPTION
VehicleHandler overrides the == operator and makes it use VehicleHandler.Equals(Object) for comparison logic. This results in an error when obj1 is null. Added a null check to the == operator to properly handle this case.